### PR TITLE
Centers and hides the edges of the image if it is too wide to fit the browser window

### DIFF
--- a/Preview in browser.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Preview in browser.sketchplugin/Contents/Sketch/script.cocoascript
@@ -9,7 +9,7 @@ var onRun = function(context) {
     artboardname = artboardname.replace(/['|'|/|#|.|\\|"|"]/g,'')
     var filename = NSTemporaryDirectory() + artboardname + ".png"
     doc.saveArtboardOrSlice_toFile(scaleArtboard(artboard),filename)
-    var htmlContent = NSString.stringWithString_("<html><head><meta charset='UTF-8'></head><body style='text-align: center; margin: 0; padding: 0; background:" + colorToRGBA(artboard.backgroundColor()) + ";'> <img width=" + (artboard.frame()).width() + " src='./" + artboardname + ".png' center top no-repeat;'></body></html>");
+    var htmlContent = NSString.stringWithString_("<html><head><meta charset='UTF-8'></head><body style='overflow-x: hidden; text-align: center; margin: 0; padding: 0; background:" + colorToRGBA(artboard.backgroundColor()) + ";'><img style='position:absolute; left:50%; margin-left:-" + ((artboard.frame()).width() / 2) + "px;' width=" + (artboard.frame()).width() + " src='./" + artboardname + ".png' center top no-repeat;'></body></html>");
     var filepath = NSTemporaryDirectory() + artboardname + ".html";
     htmlContent.dataUsingEncoding_(NSUTF8StringEncoding).writeToFile_atomically_(filepath, true);
     var file = NSURL.fileURLWithPath(filepath)


### PR DESCRIPTION
Useful when designing for large displays and you want to see your design in more narrow browser windows. At the moment, you need to manually center the image with the vertical scroll bar, this change keeps the image centered even when it is wider than your browser window.